### PR TITLE
#27_userAtom修正

### DIFF
--- a/Atoms/userAtom.tsx
+++ b/Atoms/userAtom.tsx
@@ -1,10 +1,10 @@
 import { atom, RecoilState } from "recoil";
 
 type User = {
-	uid?: string;
+	uid: string;
 };
 
 export const userState: RecoilState<User> = atom({
 	key: "userState",
-	default: {},
+	default: { uid: "" },
 });


### PR DESCRIPTION
型エラーの修正：
defaultに、Userと同じオブジェクトリテラルの初期値default: { uid: ""}を追加

close #27 